### PR TITLE
画像Post時のメモリリーク解消

### DIFF
--- a/R9HTTPRequest/R9HTTPRequest.m
+++ b/R9HTTPRequest/R9HTTPRequest.m
@@ -37,7 +37,7 @@ static NSString *boundary = @"----------0xKhTmLbOuNdArY";
 
 + (BOOL)automaticallyNotifiesObserversForKey:(NSString*)key
 {
-    if ([key isEqualToString:@"isExecuting"] || 
+    if ([key isEqualToString:@"isExecuting"] ||
         [key isEqualToString:@"isFinished"]) {
         return YES;
     }
@@ -70,7 +70,7 @@ static NSString *boundary = @"----------0xKhTmLbOuNdArY";
         _fileInfo = [[NSMutableDictionary alloc] init];
         _shouldRedirect = YES;
         _HTTPMethod = @"GET";
-    }  
+    }
     return self;
 }
 
@@ -170,12 +170,12 @@ static NSString *boundary = @"----------0xKhTmLbOuNdArY";
 #pragma mark - NSURLConnectionDelegate and NSURLConnectionDataDelegate methods
 
 // リダイレクトの処理
-- (NSURLRequest *)connection:(NSURLConnection *)connection 
+- (NSURLRequest *)connection:(NSURLConnection *)connection
              willSendRequest:(NSURLRequest *)request redirectResponse:(NSURLResponse *)response
 {
     if (response && self.shouldRedirect == NO) {
         return nil;
-    } 
+    }
     return request;
 }
 
@@ -236,6 +236,11 @@ static NSString *boundary = @"----------0xKhTmLbOuNdArY";
             //NSLog(@"is main thread:%d", [[NSThread currentThread] isMainThread]);
             self.completionHandler(responseHeader, responseString);
         }];
+
+        // メモリリーク対策 by @hisasann
+        _headers = nil;
+        _bodies = nil;
+        _fileInfo = nil;
     }];
     [self finish];
 }


### PR DESCRIPTION
こんにちは、hisasannともうします。

setData:(NSData *)data withFileName:(NSString *)fileName andContentType:(NSString *)contentType forKey:(NSString *)key

の中で使っている、_fileInfoが画像Post後に破棄されず写真をアップロードするたびに少しずつメモリ利用率が上昇しておりましたので、気になった3つのインスタンス変数にnilを入れメモリリークを解消してみました。

もっとよい方法があるかもしれませんが、応急的に入れてみました。

ではでは。
